### PR TITLE
Исправлено значение по умолчанию для подсказок по орг-ии

### DIFF
--- a/src/SuggestModel.cs
+++ b/src/SuggestModel.cs
@@ -61,7 +61,7 @@ namespace suggestionscsharp {
         public AddressData[] locations { get; set; }
         public AddressData[] locations_boost { get; set; }
         public PartyStatus[] status { get; set; }
-        public PartyType type { get; set; }
+        public PartyType? type { get; set; }
         public PartySuggestQuery(string query) : base(query) { }
     }
 


### PR DESCRIPTION
Исправлено значение по умолчанию (0 (LEGAL) -> null) для подсказок по организации, которое приводило к поиску по юрлицам, а не по всем типам организаций